### PR TITLE
Focus point editor: share in-flight AJAX requests instead of firing duplicates

### DIFF
--- a/assets/js/focus-point-editor.js
+++ b/assets/js/focus-point-editor.js
@@ -830,6 +830,7 @@
 				return globalFocusPointCache.get(imageUrl);
 			}
 
+			const inflight = (async () => {
 			try {
 				const response = await fetch(
 					`${ajaxUrl}?action=mwe_get_global_focus_point&image_url=${encodeURIComponent(imageUrl)}&nonce=${nonce}`
@@ -852,6 +853,9 @@
 			// Cache null result to avoid repeated failed requests
 			globalFocusPointCache.set(imageUrl, null);
 			return null;
+		})();
+			globalFocusPointCache.set(imageUrl, inflight);
+			return inflight;
 		}
 
 		// Cache for attachment data by ID
@@ -872,6 +876,7 @@
 				return attachmentDataCache.get(cacheKey);
 			}
 
+			const inflight = (async () => {
 			try {
 				const response = await fetch(
 					`${ajaxUrl}?action=mwe_get_attachment_data&attachment_id=${attachmentId}&nonce=${nonce}`
@@ -894,6 +899,9 @@
 			// Cache null result to avoid repeated failed requests
 			attachmentDataCache.set(cacheKey, null);
 			return null;
+		})();
+			attachmentDataCache.set(cacheKey, inflight);
+			return inflight;
 		}
 
 		/**


### PR DESCRIPTION
### Problem

`fetchGlobalFocusPoint()` and `fetchAttachmentData()` in `assets/js/focus-point-editor.js` cache **results**, but not **in-flight requests**. Inside the Etch builder, canvas re-renders (slider autoplay, component re-mounts) trigger many concurrent callbacks for the same images before the first response lands — and every caller fires its own `admin-ajax.php` request.

Measured on a production-representative staging site (Etch 1.6.4, plugin 1.2.10):

- 2,057 `mwe_get_global_focus_point` requests in a single working day
- one slider-nav arrow image fetched **101 times** in a two-minute window
- a single builder session: 71 requests for 26 unique URLs (45 duplicates)

Each request is a full WordPress bootstrap on the server, so builder sessions on image-heavy pages generate a steady ~1–4 requests/second of redundant admin-ajax load.

### Fix

Store the **promise** in the existing caches at request start, instead of storing the resolved value at request end. Concurrent callers for the same URL/ID then await the same request; each unique image costs exactly one AJAX call per session. The cache entry is later overwritten with the resolved value by the existing `set()` calls, so cache behavior after resolution is unchanged, including the cached-`null` failure path.

Verified after the patch: the same builder session fires 26 requests for 26 unique URLs (0 duplicates). No behavior change for single callers; no API or markup changes.

### Possible follow-up (not in this PR)

Debouncing the MutationObserver-driven scan would stop canvas animations from retriggering image processing at all — the dedup above already removes the network cost, so that would be purely a CPU nicety.

---

Thanks for the plugin — the focus-point editing workflow is genuinely useful. Happy to adjust anything about this change.
